### PR TITLE
[CELEBORN-1838] Interrupt spark task should not report fetch failure

### DIFF
--- a/client-spark/spark-3-4/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
+++ b/client-spark/spark-3-4/src/main/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReader.scala
@@ -18,12 +18,14 @@
 package org.apache.spark.shuffle.celeborn
 
 import java.io.IOException
+import java.nio.file.Files
 import java.util
-import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ThreadPoolExecutor, TimeoutException, TimeUnit}
 import java.util.concurrent.atomic.AtomicReference
 
 import scala.collection.JavaConverters._
 
+import com.google.common.annotations.VisibleForTesting
 import org.apache.spark.{Aggregator, InterruptibleIterator, ShuffleDependency, TaskContext}
 import org.apache.spark.celeborn.ExceptionMakerHelper
 import org.apache.spark.internal.Logging
@@ -33,14 +35,14 @@ import org.apache.spark.shuffle.celeborn.CelebornShuffleReader.streamCreatorPool
 import org.apache.spark.util.CompletionIterator
 import org.apache.spark.util.collection.ExternalSorter
 
-import org.apache.celeborn.client.ShuffleClient
+import org.apache.celeborn.client.{DummyShuffleClient, ShuffleClient}
 import org.apache.celeborn.client.ShuffleClientImpl.ReduceFileGroups
 import org.apache.celeborn.client.read.{CelebornInputStream, MetricsCallback}
 import org.apache.celeborn.common.CelebornConf
 import org.apache.celeborn.common.exception.{CelebornIOException, PartitionUnRetryAbleException}
 import org.apache.celeborn.common.network.client.TransportClient
 import org.apache.celeborn.common.network.protocol.TransportMessage
-import org.apache.celeborn.common.protocol.{MessageType, PartitionLocation, PbOpenStreamList, PbOpenStreamListResponse, PbStreamHandler}
+import org.apache.celeborn.common.protocol._
 import org.apache.celeborn.common.protocol.message.StatusCode
 import org.apache.celeborn.common.util.{JavaUtils, ThreadUtils, Utils}
 
@@ -56,18 +58,34 @@ class CelebornShuffleReader[K, C](
     shuffleIdTracker: ExecutorShuffleIdTracker)
   extends ShuffleReader[K, C] with Logging {
 
-  private val dep = handle.dependency
-  private val shuffleClient = ShuffleClient.get(
-    handle.appUniqueId,
-    handle.lifecycleManagerHost,
-    handle.lifecycleManagerPort,
-    conf,
-    handle.userIdentifier,
-    handle.extension)
+  val mockReader = conf.testMockShuffleReader
+
+  private val dep =
+    if (mockReader) {
+      null
+    } else {
+      handle.dependency
+    }
+
+  @VisibleForTesting
+  val shuffleClient =
+    if (mockReader) {
+      new DummyShuffleClient(conf, Files.createTempFile("test", "mockfile").toFile)
+    } else {
+      ShuffleClient.get(
+        handle.appUniqueId,
+        handle.lifecycleManagerHost,
+        handle.lifecycleManagerPort,
+        conf,
+        handle.userIdentifier,
+        handle.extension)
+    }
 
   private val exceptionRef = new AtomicReference[IOException]
-  private val throwsFetchFailure = handle.throwsFetchFailure
-  private val encodedAttemptId = SparkCommonUtils.getEncodedAttemptNumber(context)
+  private val throwsFetchFailure =
+    if (mockReader) conf.clientStageRerunEnabled else handle.throwsFetchFailure
+  private val encodedAttemptId =
+    if (mockReader) 0 else SparkCommonUtils.getEncodedAttemptNumber(context)
 
   override def read(): Iterator[Product2[K, C]] = {
 
@@ -103,15 +121,30 @@ class CelebornShuffleReader[K, C](
     val startTime = System.currentTimeMillis()
     val fetchTimeoutMs = conf.clientFetchTimeoutMs
     val localFetchEnabled = conf.enableReadLocalShuffleFile
+    val testSparkSpeculation = conf.testMockSparkSpeculation
     val localHostAddress = Utils.localHostName(conf)
     val shuffleKey = Utils.makeShuffleKey(handle.appUniqueId, shuffleId)
     var fileGroups: ReduceFileGroups = null
     try {
+      if (testSparkSpeculation) {
+
+        val contextAttemptId = context.taskAttemptId()
+        if (contextAttemptId == 0) {
+          logInfo(s"test spark speculation, sleep 15s")
+          Thread.sleep(35000)
+        }
+        if (contextAttemptId == 1) {
+          logInfo(s"test spark speculation, sleep 15s")
+          Thread.sleep(45000)
+        }
+      }
       // startPartition is irrelevant
       fileGroups = shuffleClient.updateFileGroup(shuffleId, startPartition)
     } catch {
       case ce @ (_: CelebornIOException | _: PartitionUnRetryAbleException) =>
-        handleFetchExceptions(handle.shuffleId, shuffleId, 0, ce)
+        // if a task is interrupted, should not report fetch failure
+        // if a task update file group timeout, should not report fetch failure
+        checkAndReportFetchFailureForUpdateFileGroupFailure(shuffleId, ce)
       case e: Throwable => throw e
     }
 
@@ -369,7 +402,22 @@ class CelebornShuffleReader[K, C](
     }
   }
 
-  private def handleFetchExceptions(
+  @VisibleForTesting
+  def checkAndReportFetchFailureForUpdateFileGroupFailure(
+      celebornShuffleId: Int,
+      ce: Throwable): Unit = {
+    if (ce.getCause != null &&
+      ce.getCause.isInstanceOf[InterruptedException] || ce.getCause.isInstanceOf[
+        TimeoutException]) {
+      logWarning(s"fetch shuffle ${celebornShuffleId} timeout or interrupt", ce)
+      throw ce
+    } else {
+      handleFetchExceptions(handle.shuffleId, celebornShuffleId, 0, ce)
+    }
+  }
+
+  @VisibleForTesting
+  def handleFetchExceptions(
       appShuffleId: Int,
       shuffleId: Int,
       partitionId: Int,

--- a/client-spark/spark-3-4/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
+++ b/client-spark/spark-3-4/src/test/scala/org/apache/spark/shuffle/celeborn/CelebornShuffleReaderSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.celeborn
+
+import java.util.concurrent.TimeoutException
+
+import org.apache.spark.TaskContext
+import org.apache.spark.shuffle.ShuffleReadMetricsReporter
+import org.mockito.Mockito
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.celeborn.client.DummyShuffleClient
+import org.apache.celeborn.common.CelebornConf
+import org.apache.celeborn.common.exception.CelebornIOException
+
+class CelebornShuffleReaderSuite extends AnyFunSuite {
+
+  /**
+   * Due to spark limitations, spark local mode can not test speculation tasks ,
+   * test the method `checkAndReportFetchFailureForUpdateFileGroupFailure`
+   */
+  test("CELEBORN-1838 test check report fetch failure exceptions ") {
+    val handler = Mockito.mock(classOf[CelebornShuffleHandle[Int, Int, Int]])
+    val context = Mockito.mock(classOf[TaskContext])
+    val metricReporter = Mockito.mock(classOf[ShuffleReadMetricsReporter])
+    val conf = new CelebornConf()
+    conf.set("celeborn.test.client.mockShuffleReader", "true")
+    conf.set("celeborn.client.spark.stageRerun.enabled", "true")
+
+    val shuffleReader =
+      new CelebornShuffleReader[Int, Int](handler, 0, 0, 0, 0, context, conf, metricReporter, null)
+
+    val exception1: Throwable = new CelebornIOException("test1", new InterruptedException("test1"))
+    val exception2: Throwable = new CelebornIOException("test2", new TimeoutException("test2"))
+    val exception3: Throwable = new CelebornIOException("test3")
+    val exception4: Throwable = new CelebornIOException("test4")
+
+    try {
+      shuffleReader.checkAndReportFetchFailureForUpdateFileGroupFailure(0, exception1)
+    } catch {
+      case _: Throwable =>
+    }
+    try {
+      shuffleReader.checkAndReportFetchFailureForUpdateFileGroupFailure(0, exception2)
+    } catch {
+      case _: Throwable =>
+    }
+    try {
+      shuffleReader.checkAndReportFetchFailureForUpdateFileGroupFailure(0, exception3)
+    } catch {
+      case _: Throwable =>
+    }
+    assert(
+      shuffleReader.shuffleClient.asInstanceOf[DummyShuffleClient].fetchFailureCount.get() === 1)
+    try {
+      shuffleReader.checkAndReportFetchFailureForUpdateFileGroupFailure(0, exception4)
+    } catch {
+      case _: Throwable =>
+    }
+    assert(
+      shuffleReader.shuffleClient.asInstanceOf[DummyShuffleClient].fetchFailureCount.get() === 2)
+
+  }
+}

--- a/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
+++ b/client/src/main/java/org/apache/celeborn/client/DummyShuffleClient.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,8 @@ public class DummyShuffleClient extends ShuffleClient {
 
   private final Map<Integer, ConcurrentHashMap<Integer, PartitionLocation>> reducePartitionMap =
       new HashMap<>();
+
+  public AtomicInteger fetchFailureCount = new AtomicInteger();
 
   public DummyShuffleClient(CelebornConf conf, File file) throws Exception {
     this.os = new BufferedOutputStream(new FileOutputStream(file));
@@ -180,6 +183,7 @@ public class DummyShuffleClient extends ShuffleClient {
 
   @Override
   public boolean reportShuffleFetchFailure(int appShuffleId, int shuffleId) {
+    fetchFailureCount.incrementAndGet();
     return true;
   }
 

--- a/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
+++ b/client/src/main/java/org/apache/celeborn/client/ShuffleClientImpl.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import scala.Tuple2;
+import scala.Tuple3;
 import scala.reflect.ClassTag$;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -170,7 +171,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   // key: shuffleId
-  protected final Map<Integer, Tuple2<ReduceFileGroups, String>> reduceFileGroupsMap =
+  protected final Map<Integer, Tuple3<ReduceFileGroups, String, Exception>> reduceFileGroupsMap =
       JavaUtils.newConcurrentHashMap();
 
   public ShuffleClientImpl(String appUniqueId, CelebornConf conf, UserIdentifier userIdentifier) {
@@ -1741,11 +1742,12 @@ public class ShuffleClientImpl extends ShuffleClient {
     return true;
   }
 
-  protected Tuple2<ReduceFileGroups, String> loadFileGroupInternal(
+  protected Tuple3<ReduceFileGroups, String, Exception> loadFileGroupInternal(
       int shuffleId, boolean isSegmentGranularityVisible) {
     {
       long getReducerFileGroupStartTime = System.nanoTime();
       String exceptionMsg = null;
+      Exception exception = null;
       try {
         if (lifecycleManagerRef == null) {
           exceptionMsg = "Driver endpoint is null!";
@@ -1767,9 +1769,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                   shuffleId,
                   TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - getReducerFileGroupStartTime),
                   response.fileGroup().size());
-              return Tuple2.apply(
+              return Tuple3.apply(
                   new ReduceFileGroups(
                       response.fileGroup(), response.attempts(), response.partitionIds()),
+                  null,
                   null);
             case SHUFFLE_NOT_REGISTERED:
               logger.warn(
@@ -1778,9 +1781,10 @@ public class ShuffleClientImpl extends ShuffleClient {
                   response.status(),
                   shuffleId);
               // return empty result
-              return Tuple2.apply(
+              return Tuple3.apply(
                   new ReduceFileGroups(
                       response.fileGroup(), response.attempts(), response.partitionIds()),
+                  null,
                   null);
             case STAGE_END_TIME_OUT:
             case SHUFFLE_DATA_LOST:
@@ -1799,8 +1803,9 @@ public class ShuffleClientImpl extends ShuffleClient {
         }
         logger.error("Exception raised while call GetReducerFileGroup for {}.", shuffleId, e);
         exceptionMsg = e.getMessage();
+        exception = e;
       }
-      return Tuple2.apply(null, exceptionMsg);
+      return Tuple3.apply(null, exceptionMsg, exception);
     }
   }
 
@@ -1813,21 +1818,22 @@ public class ShuffleClientImpl extends ShuffleClient {
   public ReduceFileGroups updateFileGroup(
       int shuffleId, int partitionId, boolean isSegmentGranularityVisible)
       throws CelebornIOException {
-    Tuple2<ReduceFileGroups, String> fileGroupTuple =
+    Tuple3<ReduceFileGroups, String, Exception> fileGroupTuple =
         reduceFileGroupsMap.compute(
             shuffleId,
             (id, existsTuple) -> {
-              if (existsTuple == null || existsTuple._1 == null) {
+              if (existsTuple == null || existsTuple._1() == null) {
                 return loadFileGroupInternal(shuffleId, isSegmentGranularityVisible);
               } else {
                 return existsTuple;
               }
             });
-    if (fileGroupTuple._1 == null) {
+    if (fileGroupTuple._1() == null) {
       throw new CelebornIOException(
-          loadFileGroupException(shuffleId, partitionId, (fileGroupTuple._2)));
+          loadFileGroupException(shuffleId, partitionId, (fileGroupTuple._2())),
+          fileGroupTuple._3());
     } else {
-      return fileGroupTuple._1;
+      return fileGroupTuple._1();
     }
   }
 
@@ -1896,7 +1902,7 @@ public class ShuffleClientImpl extends ShuffleClient {
   }
 
   @VisibleForTesting
-  public Map<Integer, Tuple2<ReduceFileGroups, String>> getReduceFileGroupsMap() {
+  public Map<Integer, Tuple3<ReduceFileGroups, String, Exception>> getReduceFileGroupsMap() {
     return reduceFileGroupsMap;
   }
 

--- a/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
+++ b/common/src/main/scala/org/apache/celeborn/common/CelebornConf.scala
@@ -1341,6 +1341,8 @@ class CelebornConf(loadDefaults: Boolean) extends Cloneable with Logging with Se
   def testMockCommitFilesFailure: Boolean = get(TEST_MOCK_COMMIT_FILES_FAILURE)
   def testMockShuffleLost: Boolean = get(TEST_CLIENT_MOCK_SHUFFLE_LOST)
   def testMockShuffleLostShuffle: Int = get(TEST_CLIENT_MOCK_SHUFFLE_LOST_SHUFFLE)
+  def testMockSparkSpeculation: Boolean = get(TEST_CLIENT_MOCK_SPARK_SPECULATION_TASK)
+  def testMockShuffleReader: Boolean = get(TEST_CLIENT_MOCK_SHUFFLE_READER)
   def testPushPrimaryDataTimeout: Boolean = get(TEST_CLIENT_PUSH_PRIMARY_DATA_TIMEOUT)
   def testPushReplicaDataTimeout: Boolean = get(TEST_WORKER_PUSH_REPLICA_DATA_TIMEOUT)
   def testRetryRevive: Boolean = get(TEST_CLIENT_RETRY_REVIVE)
@@ -4347,10 +4349,30 @@ object CelebornConf extends Logging {
       .internal
       .categories("test", "client")
       .doc("Mock shuffle lost for shuffle")
-      .version("0.5.2")
+      .version("0.5.3")
       .internal
       .intConf
       .createWithDefault(0)
+
+  val TEST_CLIENT_MOCK_SPARK_SPECULATION_TASK: ConfigEntry[Boolean] =
+    buildConf("celeborn.test.client.mockSparkSpeculationTask")
+      .internal
+      .categories("test", "client")
+      .doc("Mock spark speculation tasks for shuffle")
+      .version("0.5.3")
+      .internal
+      .booleanConf
+      .createWithDefault(false)
+
+  val TEST_CLIENT_MOCK_SHUFFLE_READER: ConfigEntry[Boolean] =
+    buildConf("celeborn.test.client.mockShuffleReader")
+      .internal
+      .categories("test", "client")
+      .doc("Mock shuffle reader for shuffle")
+      .version("0.5.3")
+      .internal
+      .booleanConf
+      .createWithDefault(false)
 
   val CLIENT_PUSH_REPLICATE_ENABLED: ConfigEntry[Boolean] =
     buildConf("celeborn.client.push.replicate.enabled")

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornStageRerunSuite.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/CelebornStageRerunSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.celeborn.common.protocol.ShuffleMode
 
-class CelebornShuffleLostSuite extends AnyFunSuite
+class CelebornStageRerunSuite extends AnyFunSuite
   with SparkTestBase
   with BeforeAndAfterEach {
 
@@ -37,7 +37,7 @@ class CelebornShuffleLostSuite extends AnyFunSuite
     System.gc()
   }
 
-  test("celeborn shuffle data lost - hash") {
+  test("stage rerun for data lost - hash") {
     val sparkConf = new SparkConf().setAppName("celeborn-demo").setMaster("local[2]")
     val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate()
     val combineResult = combine(sparkSession)
@@ -49,6 +49,8 @@ class CelebornShuffleLostSuite extends AnyFunSuite
     sparkSession.stop()
 
     val conf = updateSparkConf(sparkConf, ShuffleMode.HASH)
+    conf.set("spark.speculation", "true")
+    conf.set("spark.speculation.interval", "true")
     conf.set("spark.celeborn.client.spark.stageRerun.enabled", "true")
     conf.set("spark.celeborn.test.client.mockShuffleLost", "true")
 
@@ -68,4 +70,5 @@ class CelebornShuffleLostSuite extends AnyFunSuite
 
     celebornSparkSession.stop()
   }
+
 }

--- a/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
+++ b/tests/spark-it/src/test/scala/org/apache/celeborn/tests/spark/SparkTestBase.scala
@@ -37,7 +37,7 @@ trait SparkTestBase extends AnyFunSuite
   val Spark3OrNewer = SPARK_VERSION >= "3.0"
   println(s"Spark version is $SPARK_VERSION, Spark3OrNewer: $Spark3OrNewer")
 
-  private val sampleSeq = (1 to 78)
+  protected val sampleSeq = (1 to 78)
     .map(Random.alphanumeric)
     .toList
     .map(v => (v.toUpper, Random.nextInt(12) + 1))
@@ -78,8 +78,8 @@ trait SparkTestBase extends AnyFunSuite
     resultWithOutCeleborn
   }
 
-  def repartition(sparkSession: SparkSession): collection.Map[Char, Int] = {
-    val inputRdd = sparkSession.sparkContext.parallelize(sampleSeq, 2)
+  def repartition(sparkSession: SparkSession, parallelism: Int = 2): collection.Map[Char, Int] = {
+    val inputRdd = sparkSession.sparkContext.parallelize(sampleSeq, parallelism)
     val result = inputRdd.repartition(8).reduceByKey((acc, v) => acc + v).collectAsMap()
     result
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Do not trigger fetch failure if a spark task is speculation task.
Do not trigger fetch failure if the RPC of getReducerFileGroup is timeout.


### Why are the changes needed?
Avoid unnecessary fetch failures.


### Does this PR introduce _any_ user-facing change?
NO.


### How was this patch tested?
GA.
Manual tests result will be added before this PR is merged.
